### PR TITLE
Globally ignore compiled Python files.

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -9,3 +9,4 @@ tags
 !tags/
 tmp/**/*
 !tmp/cache/.keep
+*.pyc


### PR DESCRIPTION
The first time a `.py` file is run, or any time it's been modified, Python
creates a `.pyc` file containing a bytecode representation.

These bytecode files should always be ignored by Git, since keeping them
updated in a repo would be time consuming and would serve no purpose.